### PR TITLE
Rescue gracefully when unfavouriting fails

### DIFF
--- a/twitter_delete.rb
+++ b/twitter_delete.rb
@@ -117,9 +117,12 @@ end
 
 puts "==> Unfavoriting #{tweets_to_unfavourite.size} tweets"
 tweets_to_unfavourite.each_slice(MAX_TWEETS_PER_REQUEST) do |tweets|
-  api_call :unfavorite, tweets
+  begin
+    api_call :unfavorite, tweets
+  rescue Twitter::Error::NotFound
+    tweets_not_found += tweets
+  end
 end
-
 
 puts "==> Deleting #{tweets_to_delete.size} tweets"
 tweets_not_found = []

--- a/twitter_delete.rb
+++ b/twitter_delete.rb
@@ -116,6 +116,7 @@ if !@options[:force]
 end
 
 puts "==> Unfavoriting #{tweets_to_unfavourite.size} tweets"
+tweets_not_found = []
 tweets_to_unfavourite.each_slice(MAX_TWEETS_PER_REQUEST) do |tweets|
   begin
     api_call :unfavorite, tweets
@@ -125,7 +126,6 @@ tweets_to_unfavourite.each_slice(MAX_TWEETS_PER_REQUEST) do |tweets|
 end
 
 puts "==> Deleting #{tweets_to_delete.size} tweets"
-tweets_not_found = []
 tweets_to_delete.each_slice(MAX_TWEETS_PER_REQUEST) do |tweets|
   begin
     api_call :destroy_status, tweets


### PR DESCRIPTION
I encountered `Twitter::Error::NotFound` errors during the unfavouriting process. This `rescue` block helped.